### PR TITLE
Fixing broken add note logic and adding key to NoteList

### DIFF
--- a/client/src/Folders/FolderList/index.jsx
+++ b/client/src/Folders/FolderList/index.jsx
@@ -60,7 +60,6 @@ const FolderList = () => {
 
   // when editting folder is unfocused, close it (return to list folder item)
   const handleEditFolderBlur = () => {
-    console.log('editfolder blur')
     setEditableFolderID('')
   }
 
@@ -203,7 +202,7 @@ const FolderList = () => {
                   minWidth: 'auto',
                 },
                 '& [class*=MuiListItemSecondaryAction-root]': {
-                  right: 0
+                  right: 8
                 },
               }}
             >

--- a/client/src/Notes/NoteForm/index.jsx
+++ b/client/src/Notes/NoteForm/index.jsx
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 
 import { Box, TextField, useTheme } from "@mui/material"
 
-import { useCreateNote, useSelectedNote, useUpdateNote, useSelectedFolderID } from "@/store/store-selectors"
+import { useCreateNote, useNotes, useSelectedNote, useUpdateNote, useSelectedFolderID } from "@/store/store-selectors"
 import FlexColumn from "@/UI/FlexColumn"
 
 const NoteFormComponent = ({ formik, isNewNote }) => {
@@ -130,7 +130,8 @@ const getInitialValues = ({ isNewNote, selectedNote, selectedFolderID }) => {
   return (isNewNote ? { id: '', title: '', body: '', folder: selectedFolderID } : selectedNote )
 }
 
-const NoteForm = React.memo(({ isNewNote=false, setIsNewNote={} }) => {
+const NoteForm = React.memo(({ isNewNote=false, setIsNewNote }) => {
+  const notes = useNotes()
   const selectedNote = useSelectedNote()
   const createNote = useCreateNote()
   const updateNote = useUpdateNote()
@@ -145,6 +146,14 @@ const NoteForm = React.memo(({ isNewNote=false, setIsNewNote={} }) => {
   }, [createNote, isNewNote, setIsNewNote, updateNote])
 
   const initialValues = getInitialValues({ isNewNote, selectedNote, selectedFolderID })
+
+  useEffect(() => {
+    if (!notes.length) {
+      setIsNewNote(true)
+    } else {
+      setIsNewNote(false)
+    }
+  }, [notes.length, setIsNewNote])
 
   return (
     <Formik

--- a/client/src/Notes/NoteList/index.jsx
+++ b/client/src/Notes/NoteList/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { PropTypes } from 'prop-types/prop-types'
 
 import { useTheme } from '@emotion/react'
@@ -55,11 +55,6 @@ const NoteList = React.memo(({ setIsNewNote }) => {
   const handleDeleteNote = useCallback(id => {
     deleteNote(id)
   }, [deleteNote])
-
-  useEffect(() => {
-    if (!notes.length) return setIsNewNote(true)
-    if (selectedNote) return setIsNewNote(false)
-  }, [notes, notes.length, selectedNote, setIsNewNote])
 
   return (
     <div

--- a/client/src/Notes/NoteList/index.jsx
+++ b/client/src/Notes/NoteList/index.jsx
@@ -123,6 +123,7 @@ const NoteList = React.memo(({ setIsNewNote }) => {
                 </ListItemIcon>
               </IconButton>
               <ListItemButton
+                disableRipple
                 role={undefined}
                 onClick={handleSelectNote(id)}
                 sx={{
@@ -134,7 +135,6 @@ const NoteList = React.memo(({ setIsNewNote }) => {
                   id={labelId}
                   sx={{
                     color: palette.secondary[400],
-                    '&:hover': { color: palette.primary[200] },
                   }}
                   // take selectedNote as source of truth for title and body, because on update we do not update selectedNote
                   primary={(selectedNote.title && id === selectedNote.id) ? selectedNote.title : title}

--- a/client/src/Notes/index.jsx
+++ b/client/src/Notes/index.jsx
@@ -10,6 +10,7 @@ import Drawer from '@/Drawer'
 import FolderList from '@/Folders/FolderList'
 import NoteForm from '@/Notes/NoteForm'
 import NoteList from '@/Notes/NoteList'
+import { useNotes } from '@/store/store-selectors'
 import FlexBetween from '@/UI/FlexBetween'
 import FlexColumn from '@/UI/FlexColumn'
 import StyledTooltip from '@/UI/SyledTooltip'
@@ -20,6 +21,7 @@ const Notes = React.memo(() => {
   const [openDrawer, setOpenDrawer] = useState(false)
 
   const theme = useTheme()
+  const notes = useNotes()
 
   const isSmallerThanMedium = useMediaQuery(theme.breakpoints.down('md'))
 
@@ -91,7 +93,7 @@ const Notes = React.memo(() => {
         {isSmallerThanMedium ? null : (
           <>
             <FolderList />
-            <NoteList setIsNewNote={setIsNewNote} />
+            <NoteList key={`${notes[0]?.folder}`} setIsNewNote={setIsNewNote} />
           </>
         )}
         <NoteForm isNewNote={isNewNote} setIsNewNote={setIsNewNote} />

--- a/client/src/Notes/index.jsx
+++ b/client/src/Notes/index.jsx
@@ -36,8 +36,8 @@ const Notes = React.memo(() => {
   }
 
   const handleIsNewNote = useCallback(() => {
-    setIsNewNote(!isNewNote)
-  }, [isNewNote])
+    setIsNewNote(true)
+  }, [])
  
   return (
     <FlexColumn>

--- a/client/src/store/store-provider.jsx
+++ b/client/src/store/store-provider.jsx
@@ -6,8 +6,8 @@ import { noteAPI } from '@/apis/noteAPI'
 import { folderAPI } from '@/apis/folderAPI'
 
 const useStore = () => {
-  const [notes, setNotes] = useState([])
   const [folders, setFolders] = useState([])
+  const [notes, setNotes] = useState([])
   const [selectedNote, setSelectedNote] = useState({})
   const [selectedFolderID, setSelectedFolderID] = useState('')
 
@@ -47,15 +47,14 @@ const useStore = () => {
   const createNote = useCallback(note => {
     setSelectedNote(note)
     noteAPI.create(note)
-    .then(data => {
+    .then(() => {
       getAllNotes(selectedFolderID)  // always fetch by folder ID, it should work if folder id is null too
-      // getNote(data)
     })
     .catch(error => {
       console.log("🚀 ~ file: store-provider.jsx:54 ~ createNote ~ error:", error)
       return 
     })
-  }, [getAllNotes, getNote, selectedFolderID])
+  }, [getAllNotes, selectedFolderID])
 
   const createFolder = useCallback(folder => {
     folderAPI.create(folder)
@@ -109,15 +108,12 @@ const useStore = () => {
 
   // on first load, fetch all folders
   useEffect(() => {
-    console.log('Get all folders')
     getAllFolders()
   }, [getAllFolders])  // this cannot depend on folders, or else it refetches folders everytime
 
   // anytime folders are loaded, make sure a folder is selected (defaults to 0)
   useEffect(() => {
-    console.log('Set selected useEffect')
     if (!selectedFolderID && folders.length) {
-      console.log('Set selected folder')
       setSelectedFolderID(folders[0]?.id)
     }
   }, [folders, selectedFolderID])
@@ -125,7 +121,6 @@ const useStore = () => {
   // anytime a folder is selected, fetch all notes for that folder
   useEffect(() => {
     if (selectedFolderID) {
-      console.log('fetching notes by folder')
       getAllNotes(selectedFolderID)
     }
   }, [getAllNotes, selectedFolderID])


### PR DESCRIPTION
Fixed broken add note logic:
- useEffect in NoteList was setting bad side effect.
- moved useEffect to NoteForm and updated logic.

Added key to NoteList:
- this helps the select all notes check box keep the context for each note list.

Misc. style and clean up changes added.
- corrected padding for more vertical icon for folder item.
- removed green hover color for text on note in list.
- removed console logs from store provider.