### PR TITLE
Fix for controlling the enter key on mobile (ios) forms.

### DIFF
--- a/client/src/Folders/FolderForm/index.jsx
+++ b/client/src/Folders/FolderForm/index.jsx
@@ -32,6 +32,7 @@ const FolderFormComponent = ({ formik }) => {
         placeholder='Folder Name'
         size='small'
         variant='standard'
+        inputProps={{ enterkeyhint: 'enter' }}
         value={values.folderName ?? ''}
         onChange={handleChange}
         sx={{

--- a/client/src/Folders/FolderList/index.jsx
+++ b/client/src/Folders/FolderList/index.jsx
@@ -38,6 +38,7 @@ const FolderList = () => {
   const [isNewFolder, setIsNewFolder] = useState(false)
   const [anchorEl, setAnchorEl] = useState(null)
 
+  const isDesktop = useMemo(() => screenSize === 'large' || screenSize === 'desktop', [screenSize])
   const folderListWidth = useMemo(() => {
     if (screenSize === 'large') return 250
     if (screenSize === 'tablet') return 200
@@ -111,7 +112,7 @@ const FolderList = () => {
           >
             <StyledTooltip
               arrow
-              title="Add folder"
+              title={isDesktop ? 'Add folder' : ''}
               TransitionComponent={Fade}
               TransitionProps={{ timeout: 400 }}
             >

--- a/client/src/Navbar/index.jsx
+++ b/client/src/Navbar/index.jsx
@@ -28,6 +28,13 @@ const Navbar = () => {
       position='sticky'
       top={0}
       p='0.5rem 1.5rem 0.5rem 1rem'
+      sx={{
+        '& > a': {
+          textDecoration: 'none',
+          color: 'transparent',
+          cursor: 'none'
+        }
+      }}
     >
       {/* Left Side */}
       <Link to='/'>

--- a/client/src/Notes/ListHeader/index.jsx
+++ b/client/src/Notes/ListHeader/index.jsx
@@ -42,10 +42,7 @@ const ListHeader = ({ listState, setListState }) => {
         <ListItem
           dense
           disablePadding
-          sx={{
-            paddingLeft: "1.5rem",
-            borderBottom: `thin solid ${palette.grey[900]}`
-          }}
+          sx={{ paddingLeft: "1.5rem" }}
           secondaryAction={
             checkedIds.length ? (
               <IconButton
@@ -78,7 +75,14 @@ const ListHeader = ({ listState, setListState }) => {
             </ListItemIcon>
           </IconButton>
         </ListItem>
-      ) : <Box minHeight='55px' width='206px' />}
+      ) : (
+        <Box
+          minHeight='50px'
+          width='206px'
+          marginBottom='1rem'
+          sx={{ borderBottom: `thin solid ${palette.grey[900]}` }}
+        />
+      )}
     </>
   )
 }

--- a/client/src/Notes/NoteList/index.jsx
+++ b/client/src/Notes/NoteList/index.jsx
@@ -87,7 +87,7 @@ const NoteList = React.memo(() => {
           height: '88vh',
           overflow: 'auto',
           paddingRight: '0.5rem',
-          marginLeft: '0.5rem',
+          borderTop: `thin solid ${palette.grey[900]}`,
           borderRight: `thin solid ${palette.grey[900]}`,
         }}>
         {notes.map(({ id, title, body }) => {
@@ -101,6 +101,7 @@ const NoteList = React.memo(() => {
               sx={{
                 borderRadius: '0.5rem',
                 paddingLeft: '1rem',
+                marginLeft: '0.5rem',
                 backgroundColor: id === selectedNote.id ? palette.background.light : 'inherit',
               }}
               secondaryAction={


### PR DESCRIPTION
On a mobile (iPhone) and entering into the folder form input, the use is presented with the enter key as the `Go` button. This `Go` button doesn't submit the form. I added `inputProps={{ enterkeyhint: 'enter' }}` to try and control the type of enter button the user will see in order to get the form to submit.

I also added some styling fixes after latest push.