### PR TITLE
add ability for 'yarn test' to run & show tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "pytest tests --headless=false"
   },
   "dependencies": {
     "@emotion/react": "^11.10.8",

--- a/client/tests/base_class.py
+++ b/client/tests/base_class.py
@@ -1,6 +1,9 @@
 import time
+import sys
+import subprocess
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -9,8 +12,8 @@ class PauseFox(webdriver.Firefox):
       waiting for element to show up before failing to find it
   '''
   def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
     self.retry_time = kwargs.pop('retry_for', 1)
+    super().__init__(*args, **kwargs)
 
   def find_element(self, by, selector):
     start_time = time.time()
@@ -26,10 +29,33 @@ class BrowserSetup():
   ''' inherit from this base in your selenium tests. Will set up browser with working config
       just make sure to DELETE setup_method() in your test class!!
   '''
+
+  @property
+  def _ubuntu_version(self):
+    try:
+        with open('/etc/os-release', 'r') as os_release_file:
+            for line in os_release_file:
+                if line.startswith('PRETTY_NAME='):
+                    return line.split('=')[1].strip().strip('"')
+    except Exception:
+        pass
+    return ''
+
   def setup_method(self, method):
     options = Options()
-    options.headless = True
-    self.driver = PauseFox(options=options)
+    # supply --headless=false when running pytest in order to see browser
+    options.headless = not '--headless=false' in sys.argv
+    if self._ubuntu_version.startswith('Ubuntu 22.04'):
+      # workaround for default install of firefox on ubuntu 22.04
+      service = Service()
+      try:
+          result = subprocess.check_output(["which", "geckodriver"], stderr=subprocess.STDOUT, text=True)
+          geckodriver_path = result.strip()
+          service = Service(executable_path=geckodriver_path)
+      except subprocess.CalledProcessError as e:
+          pass
+
+    self.driver = PauseFox(options=options, service=service)
     # options = webdriver.ChromeOptions()
     # options.add_argument("--headless")  # Enable headless mode
     # self.driver = webdriver.Chrome(options=options)

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+# when running tests locally, I'd like to run 'yarn test' and see actual firefox pop up
+# this is a workaround for that: we add the pytest config option, but don't use it.
+# this is only so an error isn't thrown when we pass --headless=false
+# the actual config check is done through sys.argv because pytest doesn't allow accessing config options
+# from within the setup() method, where we set up the browser
+def pytest_addoption(parser):
+    parser.addoption(
+        "--headless", action="store", default="true", help="Run tests in headless mode: true or false"
+    )


### PR DESCRIPTION
adding 'yarn test' to run the tests was easy,
but I personally wanted to watch the tests in the browser, so I added extra code that allowed a --headless=false argument to be supplied.
so now 'yarn test' shows the browser as the tests run
(tests are run slightly differently in the test frontend workflow, so we don't have to worry about not seeing them there)