### PR TITLE
Bugfixes: ux for lists

### DIFF
--- a/client/src/Notes/ListHeader.jsx
+++ b/client/src/Notes/ListHeader.jsx
@@ -10,13 +10,19 @@ import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 
+import { INITIAL_NOTE } from '@/constants/constants'
+import { useSelectedFolderID, useStore } from '@/store/store'
 import useDeleteNote from '@/hooks/useDeleteNote'
 import useGetNotes from '@/hooks/useGetNotes'
 
 const ListHeader = ({ listState, setListState }) => {
   const { palette } = useTheme()
+
+  const { setCurrentNote, setIsNewNote, setNoteByFolderID, setSelectedNoteID } = useStore()
+
   const deleteNote = useDeleteNote()
   const { data: notes = [] } = useGetNotes()
+  const selectedFolderID = useSelectedFolderID()
   const { checkedIds, isAllChecked} = listState
   const folderIdRef = useRef(notes[0]?.folder)
   
@@ -29,8 +35,12 @@ const ListHeader = ({ listState, setListState }) => {
   const handleDeleteCheckedNotes = useCallback(() => {
     if (!Array.isArray(checkedIds) || checkedIds.length < 1) return
     deleteNote.mutate({ folder: folderIdRef.current, id: checkedIds})
+    setSelectedNoteID(null)
+    setCurrentNote(INITIAL_NOTE)
+    setNoteByFolderID(selectedFolderID, null)
+    setIsNewNote(true)
 
-  }, [checkedIds, deleteNote])
+  }, [checkedIds, deleteNote, selectedFolderID, setCurrentNote, setIsNewNote, setNoteByFolderID, setSelectedNoteID])
 
   useEffect(() => {
     if (!notes?.length) {  

--- a/client/src/Notes/NoteList.jsx
+++ b/client/src/Notes/NoteList.jsx
@@ -149,7 +149,6 @@ const NoteList = React.memo(() => {
       style={{
         width: notesListWidth,
         paddingTop: '0.5rem',
-        transition: 'all 1s ease-in-out',
       }}
     >
       <ListHeader listState={listState} setListState={setListState} />
@@ -257,7 +256,6 @@ const NoteList = React.memo(() => {
                   borderRadius: '0.5rem',
                   paddingLeft: '1rem',
                   marginLeft: '0.5rem',
-                  transition: 'all 1s ease-in-out',
                   backgroundColor: isSelected
                     ? palette.background.light
                     : 'inherit',
@@ -308,7 +306,6 @@ const NoteList = React.memo(() => {
                   role={undefined}
                   onClick={handleSelectNote(id)}
                   sx={{
-                    transition: 'all 1s ease-in-out',
                     padding: '0 38px 0 0 !important',
                     '&:hover': { backgroundColor: 'transparent' },
                   }}

--- a/client/src/Notes/index.jsx
+++ b/client/src/Notes/index.jsx
@@ -46,9 +46,9 @@ const Notes = React.memo(() => {
   const createNote = useCreateNote()
   const updateNote = useUpdateNote()
 
-  const noteID = useMemo(() => noteByFolderID[selectedFolderID], [noteByFolderID, selectedFolderID])
-  const lookupNote = useMemo(() => notes?.find(note => note?.id === noteID), [noteID, notes])
-  const isLookupIdInList = useMemo(() => notes?.some(note => note?.id === noteID), [noteID, notes])
+  const prevNoteID = useMemo(() => noteByFolderID[selectedFolderID], [noteByFolderID, selectedFolderID])
+  const lookupNote = useMemo(() => notes?.find(note => note?.id === prevNoteID), [prevNoteID, notes])
+  const isLookupIdInList = useMemo(() => notes?.some(note => note?.id === prevNoteID), [prevNoteID, notes])
   const isCurrentIdInNotes = useMemo(() => notes?.some(note => note?.id === currentNote?.id), [currentNote?.id, notes])
 
   const isDesktop = screenSize === 'large' || screenSize === 'desktop'
@@ -92,7 +92,7 @@ const Notes = React.memo(() => {
   //     'isLookupIdInList': isLookupIdInList,
   //     'isNewNote': isNewNote,
   //     'noteByFolderID': noteByFolderID,
-  //     'noteID': noteID,
+  //     'prevNoteID': prevNoteID,
   //     'notes': notes,
   //     'notesIsFetching': notesIsFetching,
   //     'notesIsLoading': notesIsLoading,
@@ -126,8 +126,8 @@ const Notes = React.memo(() => {
       })
 
       setCurrentNote(isCurrentIdInNotes ? currentNote : lookupNote ?? firstNote)
-      setSelectedNoteID(isCurrentIdInNotes ? currentNote?.id : noteID ?? firstNote?.id)
-      setNoteByFolderID(selectedFolderID, (isCurrentIdInNotes ? currentNote?.id : noteID ?? firstNote?.id))
+      setSelectedNoteID(isCurrentIdInNotes ? currentNote?.id : prevNoteID ?? firstNote?.id)
+      setNoteByFolderID(selectedFolderID, (isCurrentIdInNotes ? currentNote?.id : prevNoteID ?? firstNote?.id))
       return
     }
 
@@ -143,7 +143,7 @@ const Notes = React.memo(() => {
         'isSelectedIdInNotes': isSelectedIdInNotes,
       })
       setCurrentNote(lookupNote)
-      setSelectedNoteID(noteID)
+      setSelectedNoteID(lookupNote?.id)
     }
 
     /*
@@ -164,7 +164,7 @@ const Notes = React.memo(() => {
         setNoteByFolderID(selectedFolderID, selectedNoteID)
       }
     }
-  }, [currentNote, isCurrentIdInNotes, isLookupIdInList, isNewNote, lookupNote, noteID, notes, notesIsFetching, notesIsLoading, selectedFolderID, selectedNoteID, setCurrentNote, setNoteByFolderID, setSelectedNoteID])
+  }, [currentNote, isCurrentIdInNotes, isLookupIdInList, isNewNote, lookupNote, prevNoteID, notes, notesIsFetching, notesIsLoading, selectedFolderID, selectedNoteID, setCurrentNote, setNoteByFolderID, setSelectedNoteID])
 
   useEffect(() => {
     /*

--- a/client/src/Notes/styles.css
+++ b/client/src/Notes/styles.css
@@ -1,6 +1,8 @@
 ul > li.incoming {
-  animation: 0.5s incoming both;
+  animation: 0.6s incoming both;
+  transition: all 0.6s ease-in-out;
 }
+
 ::view-transition-old(outgoing) {
   animation: 0.8s outgoing both;
 }
@@ -19,11 +21,9 @@ ul > li.incoming {
 }
 @keyframes incoming {
   0% {
-    opacity: 0;
-    translate: 0px -25px;
+    scale: 1.4;
   }
   100% {
-    opacity: 1;
-    translate: 0 0;
+    scale: 1;
   }
 }

--- a/client/src/hooks/useDeleteNote.js
+++ b/client/src/hooks/useDeleteNote.js
@@ -53,10 +53,12 @@ export default function useDeleteNote() {
         return noteAPI.delete(noteID)
       }
 
-      const listItemEl = document.querySelector(`#note-${noteID}`)
-      listItemEl.classList.remove('incoming')
-      const listItemTextEl = document.querySelector(`#note-${noteID}-text`)
-      listItemTextEl.style.viewTransitionName = 'outgoing'
+      if (!Array.isArray(noteID)) {
+        const listItemEl = document.querySelector(`#note-${noteID}`)
+        listItemEl.classList.remove('incoming')
+        const listItemTextEl = document.querySelector(`#note-${noteID}-text`)
+        listItemTextEl.style.viewTransitionName = 'outgoing'
+      }
       
       transition = document.startViewTransition(() => {
         flushSync(() => {


### PR DESCRIPTION
Bug fixes for note list:
- Skipping startViewTransition animation when deleting more than one note.
- Clearing out store note variables when deleting notes in bulk.
  - i.e. currentNote, selectedNoteID, and so on.
  
The purpose was to clean up the note list ux.